### PR TITLE
Fixes BUCK

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -1,11 +1,11 @@
-prebuilt_cxx_binary(
+prebuilt_cxx_library(
   name = 'json',
   header_namespace = 'json',
   header_only = True,
   exported_headers = [
     'src/json.hpp',
   ],
-  visbility = [
+  visibility = [
     'PUBLIC',
   ],
 )


### PR DESCRIPTION
`visbility` looks like a typo of `visibility`. Also, is `prebuilt_cxx_binary` meant to be `prebuilt_cxx_library`? My buck (v2017.05.31.01) is complaining about unknown rule type `prebuilt_cxx_binary`.